### PR TITLE
Fixing bug that throws java.lang.NoSuchMethodError: android.test.Activity

### DIFF
--- a/android-with-test/src/main/resources/archetype-resources/application-it/src/main/java/test/HelloAndroidActivityTest.java
+++ b/android-with-test/src/main/resources/archetype-resources/application-it/src/main/java/test/HelloAndroidActivityTest.java
@@ -6,7 +6,7 @@ import ${package}.*;
 public class HelloAndroidActivityTest extends ActivityInstrumentationTestCase2<HelloAndroidActivity> {
 
     public HelloAndroidActivityTest() {
-        super(HelloAndroidActivity.class);
+        super("${package}", HelloAndroidActivity.class);
     }
 
     public void testActivity() {


### PR DESCRIPTION
Fixing bug that throws java.lang.NoSuchMethodError: android.test.ActivityInstrumentationTestCase2.<init> at least in 2.2.1 version or above.
