### PR TITLE
Run integration tests for release archetype

### DIFF
--- a/android-archetypes-it/pom.xml
+++ b/android-archetypes-it/pom.xml
@@ -18,6 +18,7 @@
     <artifactId>android-archetype-project</artifactId>
     <groupId>de.akquinet.android.archetypes</groupId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>de.akquinet.android.archetypes</groupId>
   <artifactId>android-archetypes-it</artifactId>

--- a/android-quickstart/pom.xml
+++ b/android-quickstart/pom.xml
@@ -19,6 +19,7 @@
     <groupId>de.akquinet.android.archetypes</groupId>
     <artifactId>android-archetype-project</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>de.akquinet.android.archetypes</groupId>

--- a/android-release/pom.xml
+++ b/android-release/pom.xml
@@ -19,6 +19,7 @@
     <groupId>de.akquinet.android.archetypes</groupId>
     <artifactId>android-archetype-project</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>de.akquinet.android.archetypes</groupId>

--- a/android-release/pom.xml
+++ b/android-release/pom.xml
@@ -29,6 +29,81 @@
   <description>Creates a skeleton for an Android application,
     instrumentation tests and ready-to-publish application on releases.</description>
 
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>2.0</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <configuration>
+            <localRepositoryPath>${project.build.directory}/it/repo</localRepositoryPath>
+            <debug>true</debug>
+            <showErrors>true</showErrors>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-projects</id>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <cloneProjectsTo>${project.build.directory}/it/projects</cloneProjectsTo>
+              <goals>
+                <goal>org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
+              </goals>
+              <pomIncludes>
+                <pomInclude>*</pomInclude>
+              </pomIncludes>
+              <projectsDirectory>${basedir}/src/it/projects</projectsDirectory>
+              <properties>
+                <archetypeArtifactId>${project.artifactId}</archetypeArtifactId>
+                <archetypeGroupId>${project.groupId}</archetypeGroupId>
+                <archetypeRepository>local</archetypeRepository>
+                <archetypeVersion>${project.version}</archetypeVersion>
+                <interactiveMode>false</interactiveMode>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-projects</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+              <pomIncludes>
+                <pomInclude>*/*/pom.xml</pomInclude>
+              </pomIncludes>
+              <projectsDirectory>${project.build.directory}/it/projects</projectsDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>local</id>

--- a/android-release/pom.xml
+++ b/android-release/pom.xml
@@ -29,4 +29,24 @@
   <description>Creates a skeleton for an Android application,
     instrumentation tests and ready-to-publish application on releases.</description>
 
+  <profiles>
+    <profile>
+      <id>local</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <localRepositoryPath>${settings.local.repository}</localRepositoryPath>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/android-release/src/it/projects/default/test.properties
+++ b/android-release/src/it/projects/default/test.properties
@@ -1,0 +1,3 @@
+groupId=info.manandbytes.android
+artifactId=sample
+package=info.manandbytes.android.sample


### PR DESCRIPTION
Hi!

These changes enable running of integration tests during 'integration-test' phase. What is it, an integration test (or simply IT)? In the case of archetypes, it looks like:
- generate a sample project using the current version of archetype;
- build this generated project in almost the same way as end-user will do.

Commit messages are self-explaining, but if there are any questions - feel free to ask.

For now this feature provided for andoird-release archetype only. But it seems such configuration may be pushed up to a parent POM so that other android-\* archetypes may use it too.

WDT?
