### PR TITLE
Add: plugin-version parameter.

### DIFF
--- a/android-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -11,6 +11,9 @@
     <requiredProperty key="emulator">
       <defaultValue>not-specified</defaultValue>
     </requiredProperty>
+    <requiredProperty key="plugin-version">
+      <defaultValue>2.8.4</defaultValue>
+    </requiredProperty>
   </requiredProperties>
 
   <fileSets>

--- a/android-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/android-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                 <artifactId>maven-android-plugin</artifactId>
-                <version>2.8.4</version>
+                <version>${plugin-version}</version>
                 <configuration>
                     <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
                     <assetsDirectory>${project.basedir}/assets</assetsDirectory>

--- a/android-release/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-release/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -9,6 +9,9 @@
     <requiredProperty key="emulator">
       <defaultValue>not-specified</defaultValue>
     </requiredProperty>
+    <requiredProperty key="plugin-version">
+      <defaultValue>2.8.4</defaultValue>
+    </requiredProperty>
   </requiredProperties>
 
   <fileSets>

--- a/android-release/src/main/resources/archetype-resources/pom.xml
+++ b/android-release/src/main/resources/archetype-resources/pom.xml
@@ -49,7 +49,7 @@
                 <plugin>
                     <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                     <artifactId>maven-android-plugin</artifactId>
-                    <version>2.8.3</version>
+                    <version>${plugin-version}</version>
                     <inherited>true</inherited>
                     <configuration>
                         <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>

--- a/android-with-test/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-with-test/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -9,6 +9,9 @@
     <requiredProperty key="emulator">
       <defaultValue>not-specified</defaultValue>
     </requiredProperty>
+    <requiredProperty key="plugin-version">
+      <defaultValue>2.8.4</defaultValue>
+    </requiredProperty>
   </requiredProperties>
 
   <fileSets>

--- a/android-with-test/src/main/resources/archetype-resources/application-it/pom.xml
+++ b/android-with-test/src/main/resources/archetype-resources/application-it/pom.xml
@@ -42,6 +42,7 @@
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
                 <artifactId>maven-android-plugin</artifactId>
+                <version>${plugin-version}</version>
                 <configuration>
                     <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
                     <assetsDirectory>${project.basedir}/assets</assetsDirectory>

--- a/android-with-test/src/main/resources/archetype-resources/application/pom.xml
+++ b/android-with-test/src/main/resources/archetype-resources/application/pom.xml
@@ -26,6 +26,7 @@
       <plugin>
         <groupId>com.jayway.maven.plugins.android.generation2</groupId>
         <artifactId>maven-android-plugin</artifactId>
+        <version>${plugin-version}</version>
         <configuration>
           <androidManifestFile>${project.basedir}/AndroidManifest.xml</androidManifestFile>
           <assetsDirectory>${project.basedir}/assets</assetsDirectory>


### PR DESCRIPTION
Added a plugin-version parameter to the quick start archetype which determines the version of the maven-android-plugin to use.

This is required because the quick start plugin defaults to 2.8.4, but the m2e-android plugin requires 3.0.0-alpha-2 or greater to work. So, a mechanism to over-ride the default is required.
