### PR TITLE
Push ITs to parent POM

### DIFF
--- a/android-quickstart/src/it/projects/default/test.properties
+++ b/android-quickstart/src/it/projects/default/test.properties
@@ -1,3 +1,3 @@
 groupId=info.manandbytes.android
-artifactId=sample-release
+artifactId=sample-quickstart
 package=info.manandbytes.android.sample

--- a/android-release/pom.xml
+++ b/android-release/pom.xml
@@ -38,90 +38,13 @@
       </extension>
     </extensions>
 
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>2.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <configuration>
-            <localRepositoryPath>${project.build.directory}/it/repo</localRepositoryPath>
-            <debug>true</debug>
-            <showErrors>true</showErrors>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-projects</id>
-            <goals>
-              <goal>install</goal>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <cloneProjectsTo>${project.build.directory}/it/projects</cloneProjectsTo>
-              <goals>
-                <goal>org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
-              </goals>
-              <pomIncludes>
-                <pomInclude>*</pomInclude>
-              </pomIncludes>
-              <projectsDirectory>${basedir}/src/it/projects</projectsDirectory>
-              <properties>
-                <archetypeArtifactId>${project.artifactId}</archetypeArtifactId>
-                <archetypeGroupId>${project.groupId}</archetypeGroupId>
-                <archetypeRepository>local</archetypeRepository>
-                <archetypeVersion>${project.version}</archetypeVersion>
-                <interactiveMode>false</interactiveMode>
-              </properties>
-            </configuration>
-          </execution>
-          <execution>
-            <id>verify-projects</id>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <goals>
-                <goal>verify</goal>
-              </goals>
-              <pomIncludes>
-                <pomInclude>*/*/pom.xml</pomInclude>
-              </pomIncludes>
-              <projectsDirectory>${project.build.directory}/it/projects</projectsDirectory>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>local</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-invoker-plugin</artifactId>
-            <configuration>
-              <localRepositoryPath>${settings.local.repository}</localRepositoryPath>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>

--- a/android-with-test/src/it/projects/default/test.properties
+++ b/android-with-test/src/it/projects/default/test.properties
@@ -1,3 +1,3 @@
 groupId=info.manandbytes.android
-artifactId=sample-release
+artifactId=sample-with-test
 package=info.manandbytes.android.sample

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,52 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <inherited>true</inherited>
+        <executions>
+          <execution>
+            <id>generate-projects</id>
+            <goals>
+              <goal>install</goal>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <cloneProjectsTo>${project.build.directory}/it/projects</cloneProjectsTo>
+              <goals>
+                <goal>org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
+              </goals>
+              <pomIncludes>
+                <pomInclude>*</pomInclude>
+              </pomIncludes>
+              <projectsDirectory>${basedir}/src/it/projects</projectsDirectory>
+              <properties>
+                <archetypeArtifactId>${project.artifactId}</archetypeArtifactId>
+                <archetypeGroupId>${project.groupId}</archetypeGroupId>
+                <archetypeRepository>local</archetypeRepository>
+                <archetypeVersion>${project.version}</archetypeVersion>
+                <interactiveMode>false</interactiveMode>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-projects</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+              <pomIncludes>
+                <pomInclude>*/*/pom.xml</pomInclude>
+              </pomIncludes>
+              <projectsDirectory>${project.build.directory}/it/projects</projectsDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -126,6 +172,19 @@
             <plugin>
                 <artifactId>maven-archetype-plugin</artifactId>
                 <version>2.0</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-archetype-plugin</artifactId>
+                <version>2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <localRepositoryPath>${project.build.directory}/it/repo</localRepositoryPath>
+                    <debug>true</debug>
+                    <showErrors>true</showErrors>
+                </configuration>
             </plugin>
         </plugins>
     </pluginManagement>
@@ -179,5 +238,24 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>local</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <localRepositoryPath>${settings.local.repository}</localRepositoryPath>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
Actually, these changes deprecate an android-archetypes-it module. It may be removed at all but I'm not sure if it make sense to move asserts from QuickstartArchetypeTest, ReleaseArchetypeTest and WithTestsArchetypeTest into a post-build hook script, http://maven.apache.org/plugins/maven-invoker-plugin/examples/post-build-script.html
