### PR TITLE
Supported platforms update:

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also set three optional properties :
 
 * The created 'package' with '-Dpackage=your.company.android'. By default it uses the given groupId.
 * The Android emulator's name to use with '-Demulator=my-avd'. If none specified the property <emulator> will be ignored in the pom file.
-* The targeted Android platform with '-Dplatform=7'. The Android SDK version will be automatically fetched to fit the corresponding API level. By default, it uses 7 (android 2.1).
+* The targeted Android platform with '-Dplatform=7'. The Android SDK version will be automatically fetched to fit the corresponding API level. Available API Level are 3, 4, 7, 8, 9, 10 and 14. By default, it uses 10 (android 2.3.3).
 
 Once generated, the application is ready to be built and deployed. Start an android emulator, or plug an Android dev phone,
 and launch:
@@ -47,7 +47,7 @@ This archetype creates a multi-module project containing an android application 
       -Dpackage=com.foo.bar.android
 
 The 'package' value is optional (by default use the groupId). You can also set the targeted Android platform with
-'-Dplatform=x'. By default, it use 7 (android 2.1)
+'-Dplatform=x'. By default, it uses 10 (android 2.3.3).
 
 Once generated, the application is ready to be built and tested. Start an android emulator, or plug an Android dev phone,
 and launch:
@@ -71,7 +71,7 @@ This archetype extends `android-with-test` with release management.
       -Dpackage=com.foo.bar.android
 
 The 'package' value is optional (by default use the groupId). You can also set the targeted Android platform with
-'-Dplatform=x'. By default, it use 7 (android 2.1)
+'-Dplatform=x'. By default, it uses 10 (android 2.3.3).
 
 Once generated, the application is ready to be built and tested. Start an android emulator, or plug an Android dev phone,
 and launch:

--- a/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/QuickstartArchetypeTest.java
+++ b/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/QuickstartArchetypeTest.java
@@ -71,12 +71,12 @@ public class QuickstartArchetypeTest {
 
 
         Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/quickstart-default/android-test/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/quickstart-default/android-test/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
         // Check that the Eclipse file is created (default.properties)
-        Helper.assertContains(new File("target/it/quickstart-default/android-test/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/quickstart-default/android-test/default.properties"), "target=android-10");
     }
 
     /**
@@ -204,7 +204,7 @@ public class QuickstartArchetypeTest {
         cli.add("-DarchetypeCatalog=local");
         cli.add("-DarchetypeRepository=local");
         cli.add("-Demulator=test");
-        cli.add("-Dandroid-plugin-version=3.0.0-alpha-2");
+        cli.add("-Dandroid-plugin-version=3.1.1");
         verifier.executeGoal("org.apache.maven.plugins:maven-archetype-plugin:2.0:generate");
 
 
@@ -219,12 +219,12 @@ public class QuickstartArchetypeTest {
 
 
         Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/quickstart-default/android-test/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/quickstart-default/android-test/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
         // Check that the Eclipse file is created (default.properties)
-        Helper.assertContains(new File("target/it/quickstart-default/android-test/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/quickstart-default/android-test/default.properties"), "target=android-10");
 
         // Check the emulator part
         Helper.assertContains(new File("target/it/quickstart-default/android-test/pom.xml"), "<avd>test</avd>");

--- a/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/ReleaseArchetypeTest.java
+++ b/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/ReleaseArchetypeTest.java
@@ -86,7 +86,7 @@ public class ReleaseArchetypeTest {
         Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"),"<artifactId>maven-enforcer-plugin</artifactId>");
 
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
@@ -96,11 +96,11 @@ public class ReleaseArchetypeTest {
 
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
 
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(HelloAndroidActivity.class);");
 
         // Check that the Eclipse file is created (default.properties)
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-7");
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-10");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-10");
     }
 
     /**
@@ -282,7 +282,7 @@ public class ReleaseArchetypeTest {
         Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"),"<artifactId>maven-enforcer-plugin</artifactId>");
 
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/release-default/android-test/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
@@ -292,12 +292,69 @@ public class ReleaseArchetypeTest {
 
         Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
 
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(HelloAndroidActivity.class);");
 
         // Check that the Eclipse file is created (default.properties)
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-7");
-        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-10");
+        Helper.assertContains(new File("target/it/release-default/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-10");
     }
 
+    /**
+     * Checks the release archetype with the <tt>platform</tt> parameter bellow 7 for correct constructor.
+     * @throws VerificationException
+     * @throws IOException
+     */
+    @Test
+    public void testWithTestConstructorCorrectness() throws VerificationException, IOException {
 
+        File root = Helper.prepareDirectory("release-with-platform");
+
+        Verifier verifier  = new Verifier( root.getAbsolutePath(), false );
+        verifier.setAutoclean(false);
+
+        verifier.displayStreamBuffers();
+
+        @SuppressWarnings("unchecked")
+        List<String> cli = verifier.getCliOptions();
+        cli.add("-DarchetypeArtifactId=android-release");
+        cli.add("-DarchetypeGroupId=de.akquinet.android.archetypes");
+        cli.add("-DarchetypeVersion=" + System.getProperty("archetype.version"));
+        cli.add("-DgroupId=" + Constants.TEST_GROUP_ID);
+        cli.add("-DartifactId=" + Constants.TEST_ARTIFACT_ID);
+        cli.add("-DinteractiveMode=false");
+        cli.add("-Dplatform=7");
+        cli.add("-DarchetypeCatalog=local");
+        cli.add("-DarchetypeRepository=local");
+
+        verifier.executeGoal("org.apache.maven.plugins:maven-archetype-plugin:2.0:generate");
+
+
+        // Check folder create.
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID);
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "-it");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml");
+        verifier.assertFilePresent("android-test/pom.xml");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/pom.xml");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/pom.xml");
+
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/res/values/strings.xml");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/res/layout/main.xml");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/assets");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "/src/main/java/android/archetypes/test/HelloAndroidActivity.java");
+        verifier.assertFilePresent("android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java");
+
+
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
+
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<uses-library android:name=\"android.test.runner\" />");
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
+
+        Helper.assertContains(new File("target/it/release-with-platform/android-test/"+ Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+
+    }
 }

--- a/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/WithTestsArchetypeTest.java
+++ b/android-archetypes-it/src/test/java/de/akquinet/android/archetypes/WithTestsArchetypeTest.java
@@ -77,21 +77,21 @@ public class WithTestsArchetypeTest {
 
 
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<uses-library android:name=\"android.test.runner\" />");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
 
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(HelloAndroidActivity.class);");
 
 
 
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-7");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-10");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-10");
 
     }
 
@@ -267,23 +267,81 @@ public class WithTestsArchetypeTest {
 
 
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
 
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<platform>10</platform>");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<uses-library android:name=\"android.test.runner\" />");
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
 
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(HelloAndroidActivity.class);");
 
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-7");
-        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-7");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "/default.properties"), "target=android-10");
+        Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/default.properties"), "target=android-10");
 
         Helper.assertContains(new File("target/it/with-test-default/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<avd>test</avd>");
 
     }
 
+    /**
+     * Checks the with-test archetype with the <tt>platform</tt> parameter bellow 7 for correct constructor.
+     * @throws VerificationException
+     * @throws IOException
+     */
+    @Test
+    public void testWithTestConstructorCorrectness() throws VerificationException, IOException {
 
+        File root = Helper.prepareDirectory("with-test-with-platform");
+
+        Verifier verifier  = new Verifier( root.getAbsolutePath(), false );
+        verifier.setAutoclean(false);
+
+        verifier.displayStreamBuffers();
+
+        @SuppressWarnings("unchecked")
+        List<String> cli = verifier.getCliOptions();
+        cli.add("-DarchetypeArtifactId=android-with-test");
+        cli.add("-DarchetypeGroupId=de.akquinet.android.archetypes");
+        cli.add("-DarchetypeVersion=" + System.getProperty("archetype.version"));
+        cli.add("-DgroupId=" + Constants.TEST_GROUP_ID);
+        cli.add("-DartifactId=" + Constants.TEST_ARTIFACT_ID);
+        cli.add("-DinteractiveMode=false");
+        cli.add("-Dplatform=7");
+        cli.add("-DarchetypeCatalog=local");
+        cli.add("-DarchetypeRepository=local");
+
+        verifier.executeGoal("org.apache.maven.plugins:maven-archetype-plugin:2.0:generate");
+
+
+        // Check folder create.
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID);
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "-it");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml");
+        verifier.assertFilePresent("android-test/pom.xml");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml");
+
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/res/values/strings.xml");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/res/layout/main.xml");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/assets");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "/src/main/java/android/archetypes/test/HelloAndroidActivity.java");
+        verifier.assertFilePresent("android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java");
+
+
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "<activity android:name=\".HelloAndroidActivity\">");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "/AndroidManifest.xml"), "package=\"android.archetypes.test\"");
+
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<artifactId>android-maven-plugin</artifactId>");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/pom.xml"), "<platform>7</platform>");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<uses-library android:name=\"android.test.runner\" />");
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/AndroidManifest.xml"), "<instrumentation android:targetPackage=\"android.archetypes.test\"");
+
+        Helper.assertContains(new File("target/it/with-test-with-platform/android-test/" + Constants.TEST_ARTIFACT_ID + "-it/src/main/java/android/archetypes/test/test/HelloAndroidActivityTest.java"), "super(\"android.archetypes.test\", HelloAndroidActivity.class);");
+
+    }
 }

--- a/android-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -6,7 +6,7 @@
 
   <requiredProperties>
     <requiredProperty key="platform">
-      <defaultValue>7</defaultValue>
+      <defaultValue>10</defaultValue>
     </requiredProperty>
     <requiredProperty key="emulator">
       <defaultValue>not-specified</defaultValue>

--- a/android-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/android-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -8,17 +8,22 @@
     <packaging>apk</packaging>
     <name>${artifactId}</name>
 
+    <properties>
+        <platform.version>#if(${platform} == 3) 1.5_r4
+            #elseif(${platform} == 4) 1.6_r2
+            #elseif(${platform} == 7) 2.1.2
+            #elseif(${platform} == 8) 2.2.1
+            #elseif(${platform} == 9) 2.3.1
+            #elseif(${platform} == 10) 2.3.3
+            #{else} 4.0.1.2
+            #end</platform.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.android</groupId>
             <artifactId>android</artifactId>
-            <version>
-            #if(${platform} == 3) 1.5_r4
-            #elseif(${platform} == 4) 1.6_r2
-            #elseif(${platform} == 7) 2.1.2
-            #{else} 2.2.1
-            #end
-            </version>
+            <version>${platform.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/android-release/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-release/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,7 +5,7 @@
 
     <requiredProperties>
         <requiredProperty key="platform">
-            <defaultValue>7</defaultValue>
+            <defaultValue>10</defaultValue>
         </requiredProperty>
         <requiredProperty key="emulator">
             <defaultValue>not-specified</defaultValue>

--- a/android-release/src/main/resources/archetype-resources/pom.xml
+++ b/android-release/src/main/resources/archetype-resources/pom.xml
@@ -14,30 +14,29 @@
         <module>${rootArtifactId}-it</module>
     </modules>
 
+    <properties>
+        <platform.version>#if(${platform} == 3) 1.5_r4
+            #elseif(${platform} == 4) 1.6_r2
+            #elseif(${platform} == 7) 2.1.2
+            #elseif(${platform} == 8) 2.2.1
+            #elseif(${platform} == 9) 2.3.1
+            #elseif(${platform} == 10) 2.3.3
+            #{else} 4.0.1.2
+            #end</platform.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.google.android</groupId>
                 <artifactId>android</artifactId>
-                <version>
-                #if(${platform} == 3) 1.5_r4
-                #elseif(${platform} == 4) 1.6_r2
-                #elseif(${platform} == 7) 2.1.2
-                #{else} 2.2.1
-                #end
-                </version>
+                <version>${platform.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.android</groupId>
                 <artifactId>android-test</artifactId>
-                <version>
-                #if(${platform} == 3) 1.5_r4
-                #elseif(${platform} == 4) 1.6_r2
-                #elseif(${platform} == 7) 2.1.2
-                #{else} 2.2.1
-                #end
-                </version>
+                <version>${platform.version}</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/android-with-test/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/android-with-test/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,7 +5,7 @@
 
     <requiredProperties>
         <requiredProperty key="platform">
-            <defaultValue>7</defaultValue>
+            <defaultValue>10</defaultValue>
         </requiredProperty>
         <requiredProperty key="emulator">
             <defaultValue>not-specified</defaultValue>

--- a/android-with-test/src/main/resources/archetype-resources/pom.xml
+++ b/android-with-test/src/main/resources/archetype-resources/pom.xml
@@ -13,30 +13,29 @@
         <module>${rootArtifactId}-it</module>
     </modules>
 
+    <properties>
+        <platform.version>#if(${platform} == 3) 1.5_r4
+            #elseif(${platform} == 4) 1.6_r2
+            #elseif(${platform} == 7) 2.1.2
+            #elseif(${platform} == 8) 2.2.1
+            #elseif(${platform} == 9) 2.3.1
+            #elseif(${platform} == 10) 2.3.3
+            #{else} 4.0.1.2
+            #end</platform.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>com.google.android</groupId>
                 <artifactId>android</artifactId>
-                <version>
-                #if(${platform} == 3) 1.5_r4
-                #elseif(${platform} == 4) 1.6_r2
-                #elseif(${platform} == 7) 2.1.2
-                #{else} 2.2.1
-                #end
-                </version>
+                <version>${platform.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.android</groupId>
                 <artifactId>android-test</artifactId>
-                <version>
-                #if(${platform} == 3) 1.5_r4
-                #elseif(${platform} == 4) 1.6_r2
-                #elseif(${platform} == 7) 2.1.2
-                #{else} 2.2.1
-                #end
-                </version>
+                <version>${platform.version}</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
- moved platform if/else statement to properties to avoid duplication in with-test and release archetypes
- new available platforms 9, 10 and 14
- changed default platform to 10 (I believe that 2.3.3 is now most commonly used for development)
- updated tests to reflect changes and added separated test for constructor correctness check when API level 7 or less used since 7 is not anymore default
- updated README.md for API levels

PS: Need to change used android-maven-plugin from 3.0.0 to 3.1.1 in README.md. I noticed it only after commit, sorry.
