### PR TITLE
Update archetype version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ way to initiate an android project:
     mvn archetype:generate \
       -DarchetypeArtifactId=android-quickstart \
       -DarchetypeGroupId=de.akquinet.android.archetypes \
-      -DarchetypeVersion=1.0.10 \
+      -DarchetypeVersion=1.0.11 \
       -DgroupId=your.company \
       -DartifactId=my-android-application
 
@@ -41,7 +41,7 @@ This archetype creates a multi-module project containing an android application 
     mvn archetype:generate \
       -DarchetypeArtifactId=android-with-test \
       -DarchetypeGroupId=de.akquinet.android.archetypes \
-      -DarchetypeVersion=1.0.10 \
+      -DarchetypeVersion=1.0.11 \
       -DgroupId=com.foo.bar \
       -DartifactId=my-android-project \
       -Dpackage=com.foo.bar.android
@@ -72,7 +72,7 @@ way to initiate an android project:
     mvn archetype:generate \
       -DarchetypeArtifactId=android-library-quickstart \
       -DarchetypeGroupId=de.akquinet.android.archetypes \
-      -DarchetypeVersion=1.0.10 \
+      -DarchetypeVersion=1.0.11 \
       -DgroupId=your.company \
       -DartifactId=my-android-application
 
@@ -93,7 +93,7 @@ This archetype extends `android-with-test` with release management.
     mvn archetype:generate \
       -DarchetypeArtifactId=android-release \
       -DarchetypeGroupId=de.akquinet.android.archetypes \
-      -DarchetypeVersion=1.0.10 \
+      -DarchetypeVersion=1.0.11 \
       -DgroupId=com.foo.bar \
       -DartifactId=my-android-project \
       -Dpackage=com.foo.bar.android
@@ -152,7 +152,7 @@ The android-gcm-quickstart creates a simple Google Cloud Messaging application.
     mvn archetype:generate \
       -DarchetypeArtifactId=android-gcm-quickstart \
       -DarchetypeGroupId=de.akquinet.android.archetypes \
-      -DarchetypeVersion=1.0.10 \
+      -DarchetypeVersion=1.0.11 \
       -DgroupId=your.company \
       -DartifactId=my-android-application
       -DsenderId=my-sender-id


### PR DESCRIPTION
This page http://stand.spree.de/wiki_details_maven_archetypes should be updated as well because it is confusing for new users.
